### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CryptoppECC-Encryption/Decryption using ECC(Elliptic curve cryptography).
 ### Motivation
 >[Cryptopp](https://www.cryptopp.com/) is a great free C++ class library of cryptographic schemes.
 But for performing such encryption one has to make a *static library* first from the source code files which is a headache to make for every platform.
-So, I here made a pod which runs a script to make that library depending upon your XCode SDK (both iOS and MacOSX) and then installs it as a dependency in your project.
+So, I here made a pod which runs a script to make that library depending upon your Xcode SDK (both iOS and MacOSX) and then installs it as a dependency in your project.
 I also included some Encryption/Decryption methods which took my lot of time to work properly. 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CryptoppECC for iOS and MacOSX
 
-[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/CryptoppECC.svg)](https://img.shields.io/cocoapods/v/CryptoppECC.svg)
+[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/CryptoppECC.svg)](https://img.shields.io/cocoapods/v/CryptoppECC.svg)
 [![Platform](https://img.shields.io/cocoapods/p/CryptoppECC.svg?style=flat)](http://cocoadocs.org/docsets/CryptoppECC)
 
 CryptoppECC-Encryption/Decryption using ECC(Elliptic curve cryptography).


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
